### PR TITLE
build(node): Downgrade Node to 18

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -1,7 +1,7 @@
 name: Node Release
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 18
 
 on:
   push:

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -137,7 +137,7 @@
   },
   "packageManager": "yarn@3.5.1",
   "volta": {
-    "node": "20.11.1",
+    "node": "18.19.1",
     "yarn": "3.5.1"
   }
 }


### PR DESCRIPTION
https://github.com/turingscript/tokenizers/actions/runs/8318110800
https://github.com/nodejs/node/issues/51555

# Background
--------

The issues with the Node 20 setup actions are blocking deploys. In an attempt to work around the issue, downgrade to node 18 to fix this hopefully. 
